### PR TITLE
Stop exporting development files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/Makefile export-ignore
+/phpcs.xml export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml export-ignore
+/tests/ export-ignore
+/tmp/ export-ignore


### PR DESCRIPTION
Now users will download a lighter `maria-stan`.

Command to check: `git archive HEAD | tar --list --exclude="src" --exclude="src/*"`

Exported files.
```
LICENSE.md
README.md
composer.json
extension.mysqli.neon
extension.neon
```
